### PR TITLE
Add validation message when username or password fields are empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -1179,6 +1179,12 @@
             }
             const u = document.getElementById('username').value;
             const p = document.getElementById('password').value;
+
+            if (!u || !p) {
+                document.getElementById('login-msg').innerText = "Error: Please enter a valid username and password.";
+                return;
+            }
+
             const email = u.includes('@') ? u : u + "@rekindle.ink";
             auth.signInWithEmailAndPassword(email, p).catch(e => {
                 document.getElementById('login-msg').innerText = "Error: " + e.message;
@@ -1192,6 +1198,12 @@
             }
             const u = document.getElementById('username').value;
             const p = document.getElementById('password').value;
+
+            if (!u || !p) {
+                document.getElementById('login-msg').innerText = "Error: Please enter a username and password before registering.";
+                return;
+            }
+
             const email = u.includes('@') ? u : u + "@rekindle.ink";
             auth.createUserWithEmailAndPassword(email, p).catch(e => {
                 document.getElementById('login-msg').innerText = "Error: " + e.message;


### PR DESCRIPTION
Add validation message when username or password fields are empty. This stops the empty request being sent to firebase.

This should help resolve a common support issue where users attempt to login or register without first filling in the username and password inputs.

## Username/password validated on submit

![chrome_38m1AwBMfq](https://github.com/user-attachments/assets/b23bb766-d0c5-47e2-9d16-ab3160f8238b)


## Error message when registering

<img width="544" height="528" alt="image" src="https://github.com/user-attachments/assets/28931a06-6c9e-47a5-a46a-224159408a6c" />

---

## The issue

<img width="1362" height="859" alt="image" src="https://github.com/user-attachments/assets/8bc76f1a-b4c6-4336-99d1-af52a59b8100" />

